### PR TITLE
perf(network): convertir NetworkModule a singleton con lazy initializ…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 
     compileOptions {

--- a/app/src/main/java/com/tsdc/vinilos/network/NetworkModule.kt
+++ b/app/src/main/java/com/tsdc/vinilos/network/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.tsdc.vinilos.network
 
+import com.tsdc.vinilos.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -9,32 +10,47 @@ import java.util.concurrent.TimeUnit
 object NetworkModule {
 
     private const val DEFAULT_BASE_URL = "https://backvynils-q6yc.onrender.com/"
+
+    // Cliente HTTP singleton — se crea una sola vez en toda la vida de la app
+    private val client: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = if (BuildConfig.DEBUG)
+                    HttpLoggingInterceptor.Level.BASIC
+                else
+                    HttpLoggingInterceptor.Level.NONE
+            })
+            .build()
+    }
+
+    // API de produccion — singleton, se crea una sola vez
+    private val productionApi: VinylsApiService by lazy {
+        buildApi(DEFAULT_BASE_URL)
+    }
+
+    // API de pruebas — solo se asigna en tests via setBaseUrlForTesting()
     @Volatile
-    private var baseUrl: String = DEFAULT_BASE_URL
+    private var testingApi: VinylsApiService? = null
+
+    // Punto de acceso unico: devuelve testingApi en tests, productionApi en produccion
+    val api: VinylsApiService
+        get() = testingApi ?: productionApi
 
     fun setBaseUrlForTesting(url: String) {
-        baseUrl = url
+        testingApi = buildApi(url)
     }
 
     fun resetBaseUrl() {
-        baseUrl = DEFAULT_BASE_URL
+        testingApi = null
     }
 
-    val api: VinylsApiService
-        get() {
-            val client = OkHttpClient.Builder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
-                .addInterceptor(HttpLoggingInterceptor().apply {
-                    level = HttpLoggingInterceptor.Level.BODY
-                })
-                .build()
-
-            return Retrofit.Builder()
-                .baseUrl(baseUrl)
-                .client(client)
-                .addConverterFactory(GsonConverterFactory.create())
-                .build()
-                .create(VinylsApiService::class.java)
-        }
+    private fun buildApi(baseUrl: String): VinylsApiService =
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(VinylsApiService::class.java)
 }


### PR DESCRIPTION
…ation

- OkHttpClient y Retrofit se crean una sola vez via 'by lazy' en lugar de recrearse en cada llamada al getter, eliminando overhead de memoria y CPU
- Separa productionApi (singleton lazy) de testingApi (solo en tests)
- El getter 'api' devuelve testingApi si existe, productionApi en produccion, manteniendo compatibilidad con MockServerRule sin romper el singleton
- Cambia HttpLoggingInterceptor de Level.BODY a Level.BASIC en DEBUG y Level.NONE en release, eliminando logging costoso en produccion
- Habilita buildConfig true en build.gradle para acceso a BuildConfig.DEBUG